### PR TITLE
Minor changes for clarity

### DIFF
--- a/Acknowledgment_guidelines.md
+++ b/Acknowledgment_guidelines.md
@@ -2,39 +2,39 @@
 
 ## Formal statements for acknowledgment and process
 
-When writing a paper that cites KBase in any way, you should acknowledge KBase funding as follows: “This work supported by the Office of Science, Office of Biological and Environmental Research, of the US Department of Energy under Award Numbers DE-AC02-05CH11231, DE-AC02-06CH11357, DE-AC05-00OR22725, and DE-AC02-98CH10886, as part of the DOE Systems Biology Knowledgebase.”
+When writing a paper that cites KBase in any way, you should acknowledge KBase funding as follows: “This work was supported by the Office of Science, Office of Biological and Environmental Research, of the US Department of Energy under Award Numbers DE-AC02-05CH11231, DE-AC02-06CH11357, DE-AC05-00OR22725, and DE-AC02-98CH10886, as part of the DOE Systems Biology Knowledgebase.”
 
 Cite KBase as: DOE Systems Biology Knowledgebase (KBase), http://kbase.us
 
-Email your publication to pr-approval@kbase.us for review prior to submitting for publication.  We will get back to you within two days. If you need quicker turnaround, let us know and we’ll try to accommodate.
+Be sure to send your publication to communications-approval@kbase.us for review prior to submitting for publication. Please see the [External Communications Process guide] (https://github.com/kbase/project_guides/blob/master/External%20Communications%20Process.md) for more information.
 
 ## Guidelines
 
-The following guidelines should be considered when producing materials about other work that may have used KBase resources.  This includes peer-reviewed publications submitted to journals, conference presentations (peer-reviewed or not), websites, etc. When in doubt, please contact [FIXME: who?] for further guidance.
+The following guidelines should be considered when producing materials about other work that may have used KBase resources.  This includes peer-reviewed publications submitted to journals, conference presentations (peer-reviewed or not), websites, etc. When in doubt, please contact communications-approval@kbase.us for further guidance.
 
 1. If you are planning a publication that acknowledges KBase funding (not just help or collaboration) please inform project leadership of the topic, the resources being spent, and the proposed author list. 
 
 2. When the paper enters the writing stage, reflect on what unpublished work from others on the project you are using and whether they need to be authors or acknowledged. 
 
-3. If you believe there is possible authorship or ambiguity raise the issue early. If other authors are to be brought on board, ensure they have a chance to read and edit the manuscript. 
+3. If you believe there is possible authorship or ambiguity raise the issue early. If other authors are to be brought on board, ensure that they have a chance to read and edit the manuscript before it is submitted. 
 
-4. If significant project resources and/or concepts have been used then it is likely the PIs should be included. 
+4. If significant project resources and/or concepts have been used then it is likely the PIs should be included as authors. 
 
 5. The contribution should have advanced known milestones for KBase and be reflected in its public face for program managers and others to see. 
 
 6. Using KBase as part of your own scientific research does not require KBase funding acknowledgement. 
 
-7. Papers that acknowledge KBase support (among other funding sources) should ensure proper and generous acknowledgement and/or authorship of the contributions of KBase team members.
+7. Papers that acknowledge KBase support (among other funding sources) should ensure proper and generous acknowledgement and/or authorship of the contributions of KBase team members. Please see the [External Communications Process guide] (https://github.com/kbase/project_guides/blob/master/External%20Communications%20Process.md) for guidelines on who to include as an author.
 
 8. Papers that list KBase as the sole funding source should be about deployed functions in KBase, science performed directly to support the creation or testing of KBase functionality, or may be a review. Proper acknowledgement and authorship rules apply.
 
 
 ## Classes of research products that should cite KBase
 
-The following classes of outputs should always cite KBase:
+The following types of publication should always cite KBase:
 
-1. Papers about the system, its goals, design, performance, usage etc. should cite KBase support 
+1. Papers about the system, its goals, design, performance, usage etc. should cite KBase support. 
 
-2. Papers that are about new tools or technologies that get incorporated into KBase, where a KBase supported person was involved in that tool creation, should cite KBase support if that support was material to the method or tool. 
+2. Papers about new tools or technologies that have been incorporated into KBase, where a KBase-supported person was involved in that tool creation, should cite KBase support if that support was material to the method or tool. 
 
-3. Papers about science/technology that was directly supported by KBase should both cite the main KBase paper and acknowledge KBase funding, if the science/technology was part of the agreed upon deliverables of KBase.  
+3. Papers about science/technology that was directly supported by KBase should cite the main KBase paper (or, until that is published, cite KBase as "DOE Systems Biology Knowledgebase (KBase), http://kbase.us") and should acknowledge KBase funding, if the science/technology was part of the agreed-upon deliverables of KBase.


### PR DESCRIPTION
1. Inserted a verb ("was") into acknowledgement.
2. Updated address for pre-publication approval and added link to External Communications Process guide
3. Filled in address to contact for "further guidance".
4. Minor wording change in guideline #3 for clarity.
5. Minor wording change in guideline #4, but please check that this is what was intended by this guideline.
6. Some wording tweaks to "Classes of research products that should cite KBase" for clarity.
7. Addition of fallback KBase citation (until KBase paper is published).
