### PR TITLE
Added "The MIT License (MIT)"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+The MIT License (MIT)
 Copyright (c) 2015 The KBase Project and its Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files


### PR DESCRIPTION
It turns out that this license is, verbatim, the MIT license. Added that header line for clarity.
